### PR TITLE
Keycloak as IDP and redirect to HTML to acknowledge IDP response.

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -64,12 +64,22 @@
         -->
         <activity android:name="net.openid.appauth.RedirectUriReceiverActivity">
             <intent-filter>
-                <action android:name="android.intent.action.VIEW"/>
-                <category android:name="android.intent.category.DEFAULT"/>
-                <category android:name="android.intent.category.BROWSABLE"/>
-                <data android:scheme="https"
-                  android:host="appauth.demo-app.io"
-                  android:path="/oauth2redirect"/>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="http"
+                    android:host="10.0.2.2"
+                    android:port="8088"
+                    android:path="/LibraryCrawlRedirect.html"/>
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="com.dirtroadsoftware.libraryhunt"/>
             </intent-filter>
         </activity>
     </application>

--- a/app/res/raw/auth_config.json
+++ b/app/res/raw/auth_config.json
@@ -1,11 +1,11 @@
 {
-  "client_id": "",
-  "redirect_uri": "net.openid.appauthdemo:/oauth2redirect",
+  "client_id": "vanilla",
+  "redirect_uri": "http://10.0.2.2:8088/LibraryCrawlRedirect.html",
   "authorization_scope": "openid email profile",
   "discovery_uri": "",
-  "authorization_endpoint_uri": "",
-  "token_endpoint_uri": "",
+  "authorization_endpoint_uri": "http://10.0.2.2:8080/auth/realms/libraryhunt/protocol/openid-connect/auth",
+  "token_endpoint_uri": "http://10.0.2.2:8080/auth/realms/libraryhunt/protocol/openid-connect/token",
   "registration_endpoint_uri": "",
-  "user_info_endpoint_uri": "",
-  "https_required": true
+  "user_info_endpoint_uri": "http://10.0.2.2:8080/auth/realms/libraryhunt/protocol/openid-connect/userinfo",
+  "https_required": false
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-beta6'
+        classpath 'com.android.tools.build:gradle:3.0.1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
         classpath 'org.ajoberstar:gradle-git:1.7.1'
@@ -41,7 +41,7 @@ try {
 
 project.ext.minSdkVersion = 16
 project.ext.compileSdkVersion = 26
-project.ext.buildToolsVersion = '26.0.1'
+project.ext.buildToolsVersion = '26.0.2'
 project.ext.supportLibVersion = '26.1.0'
 
 task showVersion {

--- a/public/LibraryCrawlRedirect.html
+++ b/public/LibraryCrawlRedirect.html
@@ -1,0 +1,32 @@
+<html>
+  <head>
+    <script>
+      function getParameterByName(name, url) {
+          if (!url) url = window.location.href;
+          name = name.replace(/[\[\]]/g, "\\$&");
+          var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
+              results = regex.exec(url);
+          if (!results) return null;
+          if (!results[2]) return '';
+          return decodeURIComponent(results[2].replace(/\+/g, " "));
+      }
+      var state = getParameterByName('state');
+      var session_state = getParameterByName('session_state');
+      var code = getParameterByName('code');
+      console.log("hello");
+      var intent_redirect_href = 'intent://oauth2callback?state=' + state + '&session_state=' + session_state + '&code=' + code + '#Intent;scheme=com.dirtroadsoftware.libraryhunt;package=net.openid.appauthdemo;end';
+      var onClick = 'location.href = \'' + intent_redirect_href + '\';';
+    </script>
+  </head>
+<body>
+<h1>Welcome back to Library Crawl</h1>
+
+<button id="welcomeButton" onclick="location.href = 'com.dirtroadsoftware.libraryhunt:/oauth2callback';" id="myButton" class="float-left submit-button" >Continue to Library Crawl</button>
+
+<script>
+var welcomeButton = document.getElementById('welcomeButton');
+welcomeButton.setAttribute('onclick', onClick);
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
* Two intent filters for redirect activity
  * One for initial sign in requiring user interaction
  * One for subsequent sign in attempts, while IDP session is active, because Chrome Custom Tab requires user interaction before returning to app
* Redirect HTML page for subsequent sign in's